### PR TITLE
Fix Config import to use ConfigType instead

### DIFF
--- a/custom_components/traeger/__init__.py
+++ b/custom_components/traeger/__init__.py
@@ -10,8 +10,9 @@ from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (EVENT_HOMEASSISTANT_STOP)
-from homeassistant.core import Config, Event, HomeAssistant
+from homeassistant.core import Event, HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.typing import ConfigType
 
 from .const import (CONF_PASSWORD, CONF_USERNAME, DOMAIN, PLATFORMS,
                     STARTUP_MESSAGE)
@@ -22,7 +23,7 @@ SCAN_INTERVAL = timedelta(seconds=30)
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 
-async def async_setup(hass: HomeAssistant, config: Config):  # pylint: disable=unused-argument
+async def async_setup(hass: HomeAssistant, config: ConfigType):  # pylint: disable=unused-argument
     """Set up this integration using YAML is not supported."""
     return True
 


### PR DESCRIPTION
This integration will break on HA 2024.11 due to https://github.com/home-assistant/core/pull/129163
It seems like Config was only used for (incorrect) typing; this fix is backwards compatible.